### PR TITLE
Disable running integration test environment by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run:
           name: Build and run tests
           command: |
-            mvn -DskipITs=false -P !run-integration-environment-container install
+            mvn -DskipITs=false install
       - run:
           name: Upload coverage
           command: bash <(curl -s https://codecov.io/bash)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run:
           name: Build and run tests
           command: |
-            mvn -P !run-integration-environment-container install
+            mvn -DskipITs=false -P !run-integration-environment-container install
       - run:
           name: Upload coverage
           command: bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 
 ## How to build
 
-Integration testing is enabled by default. To run full build including
+Integration testing is disabled by default. To run full build including
 integration tests use:
 ```
-mvn install
+mvn install -DskipITs=false
 ```
 
 Running integration tests is a time consuming process so to make fast build
 running unit tests only use:
 ```
-mvn install -DskipITs
+mvn install
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@
 Integration testing is disabled by default. To run full build including
 integration tests use:
 ```
+mvn install -DskipITs=false -P run-integration-environment
+```
+
+The command about automatically starts integration environment docker before
+running tests and stops after it. To start integration environment manually
+execute:
+```
+docker run -d \
+    --name java-sdk-integration-environment \
+    -p 5002:5002 -p 8545:8545 -p 7000:7000 \
+    singularitynet/java-sdk-integration-test-env
+```
+Then you can run build with integration testing using:
+```
 mvn install -DskipITs=false
 ```
 

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -179,14 +179,8 @@
 
   <profiles>
     <profile>
-      <id>run-integration-environment-container</id>
+      <id>run-integration-environment</id>
 
-      <activation>
-        <property>
-          <name>skipITs</name>
-          <value>false</value>
-        </property>
-      </activation>
       <build>
         <plugins>
 

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -182,7 +182,10 @@
       <id>run-integration-environment-container</id>
 
       <activation>
-        <property><name>!skipITs</name></property>
+        <property>
+          <name>skipITs</name>
+          <value>false</value>
+        </property>
       </activation>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
   <packaging>pom</packaging>
 
   <properties>
+    <skipITs>true</skipITs>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -234,14 +234,8 @@
 
   <profiles>
     <profile>
-      <id>run-integration-environment-container</id>
+      <id>run-integration-environment</id>
 
-      <activation>
-        <property>
-          <name>skipITs</name>
-          <value>false</value>
-        </property>
-      </activation>
       <build>
         <plugins>
 

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -237,7 +237,10 @@
       <id>run-integration-environment-container</id>
 
       <activation>
-        <property><name>!skipITs</name></property>
+        <property>
+          <name>skipITs</name>
+          <value>false</value>
+        </property>
       </activation>
       <build>
         <plugins>


### PR DESCRIPTION
Current implementation runs integration testing docker environment automatically by default. Unfortunately it prevents jitpack from building artifacts as docker is not available in this environment. This PR disables implicit running integration test environment, disables running integration tests by default. Integration tests and integration environment still can be enabled manually.