### PR TITLE
Upgrade grpc version to 1.28.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CircleCI](https://circleci.com/gh/singnet/snet-sdk-java.svg?style=svg)](https://circleci.com/gh/singnet/snet-sdk-java)
 [![codecov](https://codecov.io/gh/singnet/snet-sdk-java/branch/master/graph/badge.svg)](https://codecov.io/gh/singnet/snet-sdk-java)
 [![Release](https://jitpack.io/v/singnet/snet-sdk-java.svg)](https://jitpack.io/#singnet/snet-sdk-java)
-[![Javadoc](https://img.shields.io/badge/javadoc-master--SNAPSHOT-brightgreen)](https://jitpack.io/com/github/singnet/snet-sdk-java/snet-sdk-java/master-SNAPSHOT/javadoc)
+[![Javadoc](https://img.shields.io/badge/javadoc-0.3.2-brightgreen)](https://jitpack.io/com/github/singnet/snet-sdk-java/snet-sdk-java/0.3.2/javadoc)
 
 ## Implementing SingularityNet service client in Java
 
@@ -29,7 +29,7 @@
 ```xml
 <project>
   <properties>
-    <snet.sdk.java.version>master-SNAPSHOT</snet.sdk.java.version>
+    <snet.sdk.java.version>0.3.2</snet.sdk.java.version>
   </properties>
 
   <build>

--- a/example/android/SNetDemo/gradle.properties
+++ b/example/android/SNetDemo/gradle.properties
@@ -20,5 +20,5 @@ android.enableJetifier=true
 
 # SingularityNet Java SDK dependency versions
 snetSdkJavaVersion=master-SNAPSHOT
-grpcVersion=1.20.0
+grpcVersion=1.28.0
 protobufVersion=3.5.1

--- a/example/android/SNetDemo/gradle.properties
+++ b/example/android/SNetDemo/gradle.properties
@@ -19,6 +19,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # SingularityNet Java SDK dependency versions
-snetSdkJavaVersion=master-SNAPSHOT
+snetSdkJavaVersion=0.3.2
 grpcVersion=1.28.0
 protobufVersion=3.5.1

--- a/example/cli/pom.xml
+++ b/example/cli/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <snet.sdk.java.version>master-SNAPSHOT</snet.sdk.java.version>
     <protobuf.version>3.5.1</protobuf.version>
-    <grpc.version>1.20.0</grpc.version>
+    <grpc.version>1.28.0</grpc.version>
     <slf4j.version>1.7.29</slf4j.version>
   </properties>
 

--- a/example/cli/pom.xml
+++ b/example/cli/pom.xml
@@ -13,7 +13,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <snet.sdk.java.version>master-SNAPSHOT</snet.sdk.java.version>
+    <snet.sdk.java.version>0.3.2</snet.sdk.java.version>
     <protobuf.version>3.5.1</protobuf.version>
     <grpc.version>1.28.0</grpc.version>
     <slf4j.version>1.7.29</slf4j.version>

--- a/example/tutorial/pom.xml
+++ b/example/tutorial/pom.xml
@@ -92,7 +92,7 @@
         <configuration>
           <protocArtifact>com.google.protobuf:protoc:3.5.1:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
-          <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.20.0:exe:${os.detected.classifier}</pluginArtifact>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.28.0:exe:${os.detected.classifier}</pluginArtifact>
           <checkStaleness>true</checkStaleness>
           <protoSourceRoot>${project.build.directory}/proto</protoSourceRoot>
         </configuration>

--- a/example/tutorial/pom.xml
+++ b/example/tutorial/pom.xml
@@ -15,7 +15,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <snet.sdk.java.version>master-SNAPSHOT</snet.sdk.java.version>
+    <snet.sdk.java.version>0.3.2</snet.sdk.java.version>
   </properties>
 
   <repositories>

--- a/plugin/core/pom.xml
+++ b/plugin/core/pom.xml
@@ -23,6 +23,28 @@
     <dependency>
       <groupId>com.github.singnet.snet-sdk-java</groupId>
       <artifactId>snet-sdk-java</artifactId>
+      <exclusions>
+        <!-- TODO:
+            grpc-protobuf artifact depends on guava:28-android.
+            Android guava version doesn't inherit NonSerializableMemoizingSupplier
+            from java.util.function.Supplier which lead to error while using
+            gradle plugin to build Android app:
+                > Failed to apply plugin [id 'com.android.internal.application']
+                    > com.google.common.base.Suppliers$NonSerializableMemoizingSupplier cannot be cast to java.util.function.Supplier
+            the workaround below replaces guava Android version by JRE version
+            for plugins. It should be removed if guava is fixed.
+        -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <!-- version 28.1 corresponds to the grpc version 1.28.0 -->
+      <version>28.1-jre</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/plugin/core/pom.xml
+++ b/plugin/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.singnet.snet-sdk-java</groupId>
     <artifactId>snet-sdk-plugin-pom</artifactId>
-    <version>master-SNAPSHOT</version>
+    <version>0.3.2</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/plugin/gradle/README.md
+++ b/plugin/gradle/README.md
@@ -6,7 +6,7 @@ Sdk supports Android platfrom version 7.0 or higher (API level 24 or higher).
 
 It is convenient to add dependencies version into `gradle.properties` file:
 ```
-snetSdkJavaVersion=master-SNAPSHOT
+snetSdkJavaVersion=0.3.2
 grpcVersion=1.28.0
 protobufVersion=3.5.1
 ```

--- a/plugin/gradle/README.md
+++ b/plugin/gradle/README.md
@@ -7,7 +7,7 @@ Sdk supports Android platfrom version 7.0 or higher (API level 24 or higher).
 It is convenient to add dependencies version into `gradle.properties` file:
 ```
 snetSdkJavaVersion=master-SNAPSHOT
-grpcVersion=1.20.0
+grpcVersion=1.28.0
 protobufVersion=3.5.1
 ```
 

--- a/plugin/gradle/pom.xml
+++ b/plugin/gradle/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.singnet.snet-sdk-java</groupId>
     <artifactId>snet-sdk-plugin-pom</artifactId>
-    <version>master-SNAPSHOT</version>
+    <version>0.3.2</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/plugin/maven/pom.xml
+++ b/plugin/maven/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.github.singnet.snet-sdk-java</groupId>
     <artifactId>snet-sdk-plugin-pom</artifactId>
-    <version>master-SNAPSHOT</version>
+    <version>0.3.2</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/plugin/maven/src/test/resources/project-to-test/pom.xml
+++ b/plugin/maven/src/test/resources/project-to-test/pom.xml
@@ -11,7 +11,7 @@
   <name>Test MyMojo</name>
 
   <properties>
-    <snet.sdk.java.version>master-SNAPSHOT</snet.sdk.java.version>
+    <snet.sdk.java.version>0.3.2</snet.sdk.java.version>
   </properties>
 
   <build>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.singnet.snet-sdk-java</groupId>
     <artifactId>snet-sdk-java-pom</artifactId>
-    <version>master-SNAPSHOT</version>
+    <version>0.3.2</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <platform-contracts.version>0.3.4</platform-contracts.version>
     <snet-daemon.version>3.0.0</snet-daemon.version>
     <protobuf.version>3.5.1</protobuf.version>
-    <grpc.version>1.20.0</grpc.version>
+    <grpc.version>1.28.0</grpc.version>
     <web3j.version>4.2.0-android</web3j.version>
     <java-sdk-integration-test-env.image>singularitynet/java-sdk-integration-test-env</java-sdk-integration-test-env.image>
     <java-sdk-integration-test-env.version>3.0.0</java-sdk-integration-test-env.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.singnet.snet-sdk-java</groupId>
   <artifactId>snet-sdk-java-pom</artifactId>
-  <version>master-SNAPSHOT</version>
+  <version>0.3.2</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.singnet.snet-sdk-java</groupId>
     <artifactId>snet-sdk-java-pom</artifactId>
-    <version>master-SNAPSHOT</version>
+    <version>0.3.2</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Upgrade SDK to grpc version 1.28.0, because it allows tuning flow control window size for okhttp and fixes throughput issues on Android platform. See grpc/grpc-java#7208 (comment) for details. Workaround `grpc-protobuf` and Android Gradle plugin incompartibility.