### PR TITLE
Set Maven version to provided by Jitpack before build

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+before_install:
+  - ./set_version.sh $VERSION


### PR DESCRIPTION
It should fix difference of versions in Jitpack repo and artifacts
itselves. See https://github.com/jitpack/jitpack.io/issues/590